### PR TITLE
Fix: Conversation ID 참조 오류 및 description 저장 방식 개선

### DIFF
--- a/services/conversationService.js
+++ b/services/conversationService.js
@@ -62,7 +62,7 @@ exports.initializeConversationThread = async ({
   await conversation.save();
 
   return {
-    conversationId: conversation._id,
+    conversationId: conversation.converse_id,
     threadId: thread.id,
   };
 };
@@ -126,7 +126,7 @@ exports.generateInitialAssistantReply = async ({
   const reply = messages.data.filter(m => m.role === 'assistant').at(-1)?.content.find(c => c.type === 'text')?.text?.value || '';
 
   if (!reply) {
-    throw new Error('🛑 Assistant 응답이 비어 있습니다.');
+    throw new Error('Assistant 응답이 비어 있습니다.');
   }
 
   await Message.create({
@@ -159,7 +159,7 @@ exports.saveUserMessage = async ({ converseId, threadId, text }) => {
     return { messageId: message.message_id };
 
   } catch (err) {
-    console.error('🛑 saveUserMessage 실패:', err);
+    console.error('saveUserMessage 실패:', err);
     throw err;
   }
 };
@@ -194,7 +194,7 @@ exports.generateAssistantReply = async ({ converseId, threadId, characterName, l
 
   const [lastRun] = (await openai.beta.threads.runs.list(threadId, { limit: 1 })).data;
   if (lastRun && ['queued', 'in_progress', 'requires_action'].includes(lastRun.status)) {
-    throw new Error('🛑 이전 run이 아직 완료되지 않았습니다.');
+    throw new Error('이전 run이 아직 완료되지 않았습니다.');
   }
 
   const run = await openai.beta.threads.runs.create(threadId, {
@@ -217,7 +217,7 @@ exports.generateAssistantReply = async ({ converseId, threadId, characterName, l
 
   const reply = message.content?.[0]?.text?.value ?? '';
   if (!reply) {
-    throw new Error('🛑 Assistant 응답이 비어 있습니다.');
+    throw new Error('Assistant 응답이 비어 있습니다.');
   }
 
   await Message.create({
@@ -244,7 +244,7 @@ exports.getConversationWithMessages = async (converseId) => {
 };
 
 exports.updateConversationEndTime = async (converseId) => {
-  const conversation = await Conversation.findById(converseId);
+  const conversation = await Conversation.findOne({ converse_id: converseId });
   conversation.end_time = new Date();
   await conversation.save();
   return conversation;

--- a/services/conversationService.js
+++ b/services/conversationService.js
@@ -46,7 +46,22 @@ exports.initializeConversationThread = async ({
   const topicDescription = freeTopic
     ? freeTopic
     : `${mainTopic} - ${subTopic} - ${difficulty}`;
-  const description = freeTopic ? '자유 주제 대화' : `${mainTopic}-${subTopic}-${difficulty} 대화`;
+
+  let description;
+  if (freeTopic) {
+    description = "자유 주제 대화";
+  } else {
+    const topic = await Topic.findOne({ mainTopic });
+    if (!topic) { throw new Error('해당 mainTopic을 찾을 수 없습니다.')};
+
+    const sub = topic.subTopics.find(st => st.name === subTopic);
+    if (!sub) { throw new Error('해당 subTopic을 찾을 수 없습니다.')};
+
+    const diff = sub.difficulties.find(d => d.difficulty.trim() === difficulty.trim());
+    if (!diff) { throw new Error('해당 difficulty를 찾을 수 없습니다.')};
+
+    description = diff.description;
+  }
 
   const conversation = new Conversation({
     user_id: user._id,

--- a/services/feedbackService.js
+++ b/services/feedbackService.js
@@ -38,7 +38,6 @@ class FeedbackService {
   }
 
   async getFeedbackByMessageId(messageId) {
-    console.log("피드백 찾기 Received messageId:", messageId);
     if (!messageId) {
       throw new Error("messageId가 제공되지 않았습니다.");
     }


### PR DESCRIPTION
## 📝 PR 유형
어떤 변경 사항이 있나요? (해당하는 항목에 [x] 표시)
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 빌드 관련 변경
- [ ] 기타 (아래에 자세히 설명)

## ✨ 주요 변경 사항
### Conversation의 id 참조 오류 수정
- 문제: 기존 대화 저장 방식에서 Conversation 스키마는 Mongoose에서 자동 생성되는 _id 값으로 저장된 반면, Message와 Feedback은 converse_id 값으로 Conversation을 참조하고 있었음
- 결과: 이로 인해 Message와 Feedback에서 Conversation을 제대로 참조하지 못하여 대화 내역 조회 시 오류 발생
- 해결: Conversation 스키마도 _id 대신 converse_id 필드를 사용해 저장되도록 수정

### 일반 주제 대화인 경우, 적절한 description을 조회하여 저장
- 자유 주제가 아닌 경우, topic DB에서 mainTopic, subTopic, difficulty 조합에 해당하는 description을 조회하여 conversation.description에 반영
- 기존 하드코딩된 `${mainTopic}-${subTopic}-${difficulty} 대화` 형식 제거
